### PR TITLE
Extend the current theme rather than overwrite

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,17 +1,20 @@
-var theme = {
-    colors: {
-        accentcolor: "#31363b",
-        textcolor: "#ffffff",
-        
-        toolbar: "#40454a",
-        tab_line: "#2478c8",
-        
-        toolbar_field: "#31363b",
-        toolbar_field_text: "#ffffff",
-        
-        popup: "#31363b",
-        popup_text: "#ffffff"
-    }
-};
+let colors = {
+    accentcolor: "#31363b",
+    textcolor: "#ffffff",
 
-browser.theme.update(theme);
+    toolbar: "#40454a",
+    tab_line: "#2478c8",
+
+    toolbar_field: "#31363b",
+    toolbar_field_text: "#ffffff",
+
+    popup: "#31363b",
+    popup_text: "#ffffff"
+};
+    
+    
+(async () => {
+    let base = await browser.theme.getCurrent();
+    Object.assign(base.colors, colors);
+    browser.theme.update(base);
+});


### PR DESCRIPTION
Modified to let us extend the currently selected theme (which could be set to the default dark theme), rather than clobber other theme settings.  This way, if a different dark theme is selected as a base, the new tab page winds up staying dark without needing to import additional colors